### PR TITLE
Adding gateway fix for MAAS region controller

### DIFF
--- a/maas/maas-region-controller/Dockerfile
+++ b/maas/maas-region-controller/Dockerfile
@@ -43,6 +43,10 @@ RUN chmod +x /usr/local/bin/create-provisioning-network.sh
 COPY scripts/create-provisioning-network.service /lib/systemd/system/create-provisioning-network.service
 RUN systemctl enable create-provisioning-network.service
 
+# Fix for the gateway change bug in MAAS regiond version 2.1 from (alanmeadows)
+COPY scripts/gateway-fix.patch /tmp/gateway-fix.patch
+RUN cd /usr/lib/python3/dist-packages/maasserver/models/ && patch -p2 < /tmp/gateway-fix.patch
+
 # specify a static secret so we can register controllers
 # without having to pull the uniquely generated one
 # from this - note the secret must be a valid

--- a/maas/maas-region-controller/scripts/gateway-fix.patch
+++ b/maas/maas-region-controller/scripts/gateway-fix.patch
@@ -1,0 +1,22 @@
+--- /tmp/node.py	2016-12-13 18:15:35.957827277 +0000
++++ /usr/lib/python3/dist-packages/maasserver/models/node.py	2016-12-13 17:56:23.346482268 +0000
+@@ -2876,13 +2876,17 @@
+
+         # Try first to use DNS servers from default gateway subnets.
+         if ipv4 and gateways.ipv4 is not None:
+-            subnet = Subnet.objects.get(id=gateways.ipv4.subnet_id)
++            #subnet = Subnet.objects.get(id=gateways.ipv4.subnet_id)
++            #alanmeadows(NOTE): fix bug
++            subnet = Subnet.objects.get(id=gateways.ipv4[1])
+             if subnet.dns_servers is not None and len(subnet.dns_servers) > 0:
+                 # An IPv4 subnet is hosting the default gateway and has DNS
+                 # servers defined. IPv4 DNS servers take first-priority.
+                 return subnet.dns_servers
+         if ipv6 and gateways.ipv6 is not None:
+-            subnet = Subnet.objects.get(id=gateways.ipv6.subnet_id)
++            #subnet = Subnet.objects.get(id=gateways.ipv6.subnet_id)
++            #alanmeadows(NOTE): fix bug
++            subnet = Subnet.objects.get(id=gateways.ipv6[1])
+             if subnet.dns_servers is not None and len(subnet.dns_servers) > 0:
+                 # An IPv6 subnet is hosting the default gateway and has DNS
+                 # servers defined. IPv6 DNS servers take second-priority.


### PR DESCRIPTION
Adding the gateway fix from @alanmeadows  to the MAAS configuration.   Fixes a bug which prevents MAAS from changing the gateway in the 2.1x release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/dockerfiles/43)
<!-- Reviewable:end -->
