### PR TITLE
Initial commit of openvswitch-vswitchd container

### DIFF
--- a/openvswitch-vswitchd/Dockerfile
+++ b/openvswitch-vswitchd/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:16.04
+RUN apt-get update && \
+    apt-get install -y openvswitch-common openvswitch-switch \
+		       bridge-utils traceroute tcpdump
+CMD []


### PR DESCRIPTION
This allows our Xenial nodes to leverage a corresponding
vswitchd container, providing a closer match between
module and vswitchd service

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/dockerfiles/60)
<!-- Reviewable:end -->
