### PR TITLE
allow tcpdump to run in privileged mode

### DIFF
--- a/maas/maas-rack-controller/Dockerfile
+++ b/maas/maas-rack-controller/Dockerfile
@@ -47,6 +47,8 @@ RUN cd /usr/lib/python3/dist-packages/provisioningserver/utils/ && patch -p2 < /
 COPY scripts/ipmi.patch /tmp/ipmi.patch
 RUN cd /usr/lib/python3/dist-packages/provisioningserver/drivers/power && patch -p0 < /tmp/ipmi.patch
 
+RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
+RUN ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
 
 # initalize systemd
 CMD ["/sbin/init"]


### PR DESCRIPTION
There is currently a bug in docker where a privileged container cannot run tcpdump: https://github.com/docker/docker/issues/5490.  Due to this, maas rack controller's logs get filled with apparmor errors:

> audit: type=1400 audit(foo): apparmor="DENIED" operation="open" info="Failed name lookup - disconnected path" error=-13 profile="/usr/sbin/tcpdump" name="var/lib/docker/aufs/diff/28be8e227b3db64b0976e2aad448e76a594c8155fdb8b03f3ae2435765b7b330/etc/ld.so.cache" pid=3372 comm="tcpdump" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
provisioningserver.utils.services: [info] observe-arp[foo]: /usr/sbin/tcpdump: error while loading shared libraries: libcrypto.so.1.0.0: cannot open shared object file: Permission denied


This is a workaround to move tcpdump out of the system binaries and creates a soft link to the old tcpdump reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/dockerfiles/71)
<!-- Reviewable:end -->
