### PR TITLE
Update kube-controller-manager image

### DIFF
--- a/kube-controller-manager/Dockerfile
+++ b/kube-controller-manager/Dockerfile
@@ -1,9 +1,19 @@
 FROM ubuntu:16.04
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV container docker
+ARG KUBERNETES_VERSION=v1.5.3
 
-# Don't start any optional services except for the few we need.
-COPY kube-controller-manager /usr/bin
-RUN chmod +x /usr/bin/kube-controller-manager
-RUN apt-get update && apt-get install -y ceph-common
+ENV DEBIAN_FRONTEND=noninteractive \
+    container=docker \
+    KUBERNETES_DOWNLOAD_ROOT=https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64 \
+    KUBERNETES_COMPONENT=kube-controller-manager
+
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y \
+        ceph-common \
+        curl \
+    && curl -L ${KUBERNETES_DOWNLOAD_ROOT}/${KUBERNETES_COMPONENT} -o /usr/bin/${KUBERNETES_COMPONENT} \
+    && chmod +x /usr/bin/${KUBERNETES_COMPONENT} \
+    && apt-get purge -y --auto-remove \
+        curl \
+    && rm -rf /var/lib/apt/lists/*

--- a/kube-controller-manager/README.md
+++ b/kube-controller-manager/README.md
@@ -2,10 +2,10 @@
 
 ### Ubuntu based kube-controller-manager with Ceph Tools
 
-This is a kube-controller-manager container, based on the kubernetes v1.5.1 kube-controller-manager binary.
+This is a kube-controller-manager container, based on the kubernetes v1.5.3 kube-controller-manager binary.
 
 It is a custom image that adds in the ceph rbd utilities necessary to do ceph RBD PVCs.
 
 To install it in a kubeadm environment, update /etc/kubernetes/manifests/kube-controller-manager.yaml to point to a build for this image.  If leveraging a local docker build, you may need to update the image pull policy.
 
-If you wish to use a pre-built image, one is available on quay.io at quay.io/attcomdev/kube-controller-manager:v1.5.1
+If you wish to use a pre-built image, one is available on quay.io at quay.io/attcomdev/kube-controller-manager:v1.5.3


### PR DESCRIPTION
This commit remove the kube-controller-manager binary from the repo, which was expanding the git repo size by ~100Mb each time it was updated.
It also allows the K8s Version to be specified at build time if required for development builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/dockerfiles/75)
<!-- Reviewable:end -->
