### PR TITLE
Fix Systemd setup for running in container

### DIFF
--- a/kubeadm-ci/Dockerfile
+++ b/kubeadm-ci/Dockerfile
@@ -11,11 +11,10 @@ RUN set -x \
         curl \
         lxc \
         vim \
-        iptables
-
-RUN curl -sSL https://get.docker.com/ | sh
-
-RUN set -x \
+        iptables \
+# Install docker
+    && curl -sSL https://get.docker.com/ | sh \
+# Setup Systemd for running in a container
     && find /lib/systemd/system/sysinit.target.wants/ ! -name 'systemd-tmpfiles-setup.service' -type l -exec rm -fv {} + \
     && ls -lah /lib/systemd/system/sysinit.target.wants/ \
     && rm -fv /lib/systemd/system/multi-user.target.wants/* \

--- a/kubeadm-ci/Dockerfile
+++ b/kubeadm-ci/Dockerfile
@@ -2,26 +2,28 @@ FROM ubuntu
 MAINTAINER bjozsa@att.com
 
 ENV container docker
-RUN apt-get -y update
 
-RUN apt-get update -qq && apt-get install -qqy \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    lxc \
-    vim \
-    iptables
+RUN set -x \
+    && apt-get update -qq \
+    && apt-get install -qqy \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        lxc \
+        vim \
+        iptables
 
 RUN curl -sSL https://get.docker.com/ | sh
 
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-rm -f /lib/systemd/system/multi-user.target.wants/*;\
-rm -f /etc/systemd/system/*.wants/*;\
-rm -f /lib/systemd/system/local-fs.target.wants/*; \
-rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-rm -f /lib/systemd/system/basic.target.wants/*;\
-rm -f /lib/systemd/system/anaconda.target.wants/*;
+RUN set -x \
+    && find /lib/systemd/system/sysinit.target.wants/ ! -name 'systemd-tmpfiles-setup.service' -type l -exec rm -fv {} + \
+    && ls -lah /lib/systemd/system/sysinit.target.wants/ \
+    && rm -fv /lib/systemd/system/multi-user.target.wants/* \
+    && rm -fv /etc/systemd/system/*.wants/* \
+    && rm -fv /lib/systemd/system/local-fs.target.wants/* \
+    && rm -fv /lib/systemd/system/sockets.target.wants/*udev* \
+    && rm -fv /lib/systemd/system/sockets.target.wants/*initctl* \
+    && rm -fv /lib/systemd/system/basic.target.wants/*
 
 COPY scripts/kubeadm.sh /usr/local/bin/kubeadm.sh
 RUN chmod +x /usr/local/bin/kubeadm.sh


### PR DESCRIPTION
This commit resolves a few issues with the systemd setup for Ubuntu containers and removes a superfluous `RUN` command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/dockerfiles/76)
<!-- Reviewable:end -->
