### PR TITLE
update kube-controller-manager: v1.5.2 image on quay

### DIFF
--- a/kube-controller-manager/Dockerfile
+++ b/kube-controller-manager/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-ARG KUBERNETES_VERSION=v1.5.3
+ARG KUBERNETES_VERSION=v1.5.2
 
 ENV DEBIAN_FRONTEND=noninteractive \
     container=docker \


### PR DESCRIPTION
resolves request from @intlabs to push `kube-controller-manager:v1.5.2` as part of issue #77.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/dockerfiles/78)
<!-- Reviewable:end -->
