### PR TITLE
kubeadm-aio: change helm version

### DIFF
--- a/kubeadm-aio/Dockerfile
+++ b/kubeadm-aio/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER pete.birley@att.com
 
-ARG HELM_VERSION=v2.1.3
+ARG HELM_VERSION=v2.2.3
 
 ENV container="docker" \
     DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
users will get an error when deploying charts with Helm lower than 2.2.x. this updates it to the version we have listed as supported in our docs.