### PR TITLE
Kube-controller-manager: Move to K8s 1.6.5

### DIFF
--- a/kube-controller-manager/Dockerfile
+++ b/kube-controller-manager/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-ARG KUBERNETES_VERSION=v1.6.2
+ARG KUBERNETES_VERSION=v1.6.5
 
 ENV DEBIAN_FRONTEND=noninteractive \
     container=docker \


### PR DESCRIPTION
This PS moves the k8s image to v1.6.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/dockerfiles/98)
<!-- Reviewable:end -->
