### PR TITLE
Update k8s version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ IMAGES := \
 	helm:v2.1.3 \
 	kolla-builder:latest \
 	kube-controller-manager:latest \
-	kube-controller-manager:v1.6.2 \
+	kube-controller-manager:v1.6.7 \
 	kvm-manager:latest \
 	openvswitch-vswitchd:latest \
 	rabbitmq:3.7.0-pre-15 \

--- a/kube-controller-manager/Dockerfile
+++ b/kube-controller-manager/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-ARG KUBERNETES_VERSION=v1.6.5
+ARG KUBERNETES_VERSION=v1.6.7
 
 ENV DEBIAN_FRONTEND=noninteractive \
     container=docker \


### PR DESCRIPTION
This patchset syncs and updates the kubernetes version to 1.6.7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/dockerfiles/105)
<!-- Reviewable:end -->
