### PR TITLE
Kube Controller Manager update to K8s 1.6.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ IMAGES := \
 	helm:v2.1.3 \
 	kolla-builder:latest \
 	kube-controller-manager:latest \
-	kube-controller-manager:v1.6.7 \
+	kube-controller-manager:v1.6.8 \
 	kvm-manager:latest \
 	openvswitch-vswitchd:latest \
 	rabbitmq:3.7.0-pre-15 \

--- a/kube-controller-manager/Dockerfile
+++ b/kube-controller-manager/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-ARG KUBERNETES_VERSION=v1.6.7
+ARG KUBERNETES_VERSION=v1.6.8
 
 ENV DEBIAN_FRONTEND=noninteractive \
     container=docker \


### PR DESCRIPTION
This commit updates the Kubernetes controller manager image to v1.6.8