### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/kolla-builder/Dockerfile
+++ b/kolla-builder/Dockerfile
@@ -65,7 +65,7 @@ RUN mkdir -p .venv && \
     virtualenv .venv/kolla-builds && \
     . .venv/kolla-builds/bin/activate && \
     cd ./kolla-$KOLLA_VERSION && \
-    pip install -e . && \
+    pip install --no-cache-dir -e . && \
     mkdir -p /etc/kolla
 
 RUN mkdir -p /root/.kolla-$KOLLA_VERSION/src/$KOLLA_PROJECT && \

--- a/maas/maas-region-controller/Dockerfile
+++ b/maas/maas-region-controller/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get download maas-region-controller && \
     pg_dropcluster --stop 9.5 main
 
 # potentially used to calculate cidrs
-RUN pip3 install netaddr
+RUN pip3 install --no-cache-dir netaddr
 
 # initalize systemd
 CMD ["/sbin/init"]

--- a/simple-shaker/Dockerfile
+++ b/simple-shaker/Dockerfile
@@ -8,8 +8,8 @@ RUN apt update && install_packages python-dev wget gcc nano less \
 RUN wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py
 
-RUN pip install -U pbr setuptools
-RUN pip install pyshaker openstackclient flent==1.2.2
+RUN pip install --no-cache-dir -U pbr setuptools
+RUN pip install --no-cache-dir pyshaker openstackclient flent==1.2.2
 
 RUN wget http://ftp.br.debian.org/debian/pool/non-free/n/netperf/netperf_2.6.0-2_amd64.deb && \
     dpkg -i netperf_2.6.0-2_amd64.deb && apt install -f


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>